### PR TITLE
Fix the test of dependent-sum-template

### DIFF
--- a/dependent-sum-template/test/test.hs
+++ b/dependent-sum-template/test/test.hs
@@ -96,23 +96,22 @@ data Qux a where
 
 deriveGEq ''Foo
 deriveGEq ''Bar
-deriveGEq ''Baz
 deriveGEq ''Qux
+deriveGEq ''Baz
 
 deriveGCompare ''Foo
 deriveGCompare ''Bar
-deriveGCompare ''Baz
 deriveGCompare ''Qux
-
-instance Show (Foo a) where showsPrec = gshowsPrec
-instance Show (Bar a) where showsPrec = gshowsPrec
-instance Show (Baz a) where showsPrec = gshowsPrec
-instance Show (Qux a) where showsPrec = gshowsPrec
+deriveGCompare ''Baz
 
 deriveGShow ''Foo
+instance Show (Foo a) where showsPrec = gshowsPrec
 deriveGShow ''Bar
-deriveGShow ''Baz
+instance Show (Bar a) where showsPrec = gshowsPrec
 deriveGShow ''Qux
+instance Show (Qux a) where showsPrec = gshowsPrec
+deriveGShow ''Baz
+instance Show (Baz a) where showsPrec = gshowsPrec
 
 data Squudge a where
     E :: Ord a => Foo a -> Squudge a


### PR DESCRIPTION
[The order of TH splices is more important](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#the-order-of-th-splices-is-more-important) in GHC 9